### PR TITLE
Changes to get running from checkout on Windows 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/ 
+*.pyc 
+scritps/.pyexiftoolgui/ 
+scripts/.pyexiftoolgui/ 
+*.wp? 

--- a/scripts/petgfilehandling.py
+++ b/scripts/petgfilehandling.py
@@ -13,7 +13,7 @@
 # the GNU General Public Licence for more details.
 
 # This file is part of pyexiftoolgui.
-# pyexiftoolgui is a pySide script program that reads and writes  
+# pyexiftoolgui is a pySide script program that reads and writes
 # gps tags from/to files. It can use a "reference" image to write the
 # gps tags to a multiple set of files that are taken at the same
 # location.
@@ -43,19 +43,19 @@ def write_default_config():
     userpath = os.path.expanduser('~')
     config_filepath = os.path.join(userpath, '.pyexiftoolgui')
     if not os.path.isdir(config_filepath):
-	    os.mkdir(config_filepath)
+        os.mkdir(config_filepath)
     config_file = open(os.path.join(config_filepath, 'config.xml'), "w")
     config_file.write(config)
     config_file.close()
 
 def error_reading_configparameter(self):
     message = ("Somehow I encountered an error reading the config file.\n"
-            "This can happen when:\n- you updated from version <= 0.5 to version >= 0.6\n"
-            "- when the config file somehow got damaged.\n"
-            "- when this is the very first program start.\n\n"
-            "I will simply create a new config file. Please "
-            "check your preferences.")
-    ret = QMessageBox.warning(self, "error reading config", message) 
+               "This can happen when:\n- you updated from version <= 0.5 to version >= 0.6\n"
+               "- when the config file somehow got damaged.\n"
+               "- when this is the very first program start.\n\n"
+               "I will simply create a new config file. Please "
+               "check your preferences.")
+    ret = QMessageBox.warning(self, "error reading config", message)
 
 def read_xml_config(self):
     tempstr = lambda val: '' if val is None else val
@@ -84,18 +84,18 @@ def read_xml_config(self):
             else:
                 self.alternate_exiftool = False
         for tags in pref_record.iter('exiftooloption'):
-                self.exiftooloption.setText(tags.text)
+            self.exiftooloption.setText(tags.text)
         for tags in pref_record.iter('pref_thumbnail_preview'):
-            if tags.text == "True": 
-                self.pref_thumbnail_preview.setChecked(1) 
+            if tags.text == "True":
+                self.pref_thumbnail_preview.setChecked(1)
             else:
                 self.pref_thumbnail_preview.setChecked(0)
         for tags in pref_record.iter('def_startupfolder'):
-                self.LineEdit_def_startupfolder.setText(tags.text)
+            self.LineEdit_def_startupfolder.setText(tags.text)
         for tags in pref_record.iter('def_creator'):
-                self.def_creator.setText(tags.text)
+            self.def_creator.setText(tags.text)
         for tags in pref_record.iter('def_copyright'):
-                self.def_copyright.setText(tags.text)
+            self.def_copyright.setText(tags.text)
 
 def write_xml_config(self):
     for pref_record in self.configroot:
@@ -109,7 +109,7 @@ def write_xml_config(self):
         for tags in pref_record.iter('exiftooloption'):
             tags.text = self.exiftooloption.text()
         for tags in pref_record.iter('pref_thumbnail_preview'):
-            if self.pref_thumbnail_preview.isChecked(): 
+            if self.pref_thumbnail_preview.isChecked():
                 tags.text = "True"
             else:
                 tags.text = "False"
@@ -125,7 +125,7 @@ def write_xml_config(self):
         #print(userpath)
         self.configtree.write(os.path.join(userpath, '.pyexiftoolgui', 'config.xml'))
     except:
-            QMessageBox.critical(self, "Error!", "Unable to open config.xml for writing" )
+        QMessageBox.critical(self, "Error!", "Unable to open config.xml for writing" )
 
 
 # End of Configuration xml file
@@ -145,8 +145,12 @@ def write_default_lensdb():
     lensdb += "\t</lens>\n"
     lensdb += "</data>\n"
 
-    userpath = os.environ['HOME']
-    lensdb_file = open(os.path.join(userpath, '.pyexiftoolgui', 'lensdb.xml'), "w")
+    #userpath = os.environ.get('HOME', os.environ.get("HOMEDIR", "."))
+    userpath = os.path.expanduser('~')
+    userpath = os.path.join(userpath, '.pyexiftoolgui')
+    if not os.path.exists(userpath):
+        os.makedirs(userpath)
+    lensdb_file = open(os.path.join(userpath, 'lensdb.xml'), "w")
     lensdb_file.write(lensdb)
     lensdb_file.close()
 
@@ -186,7 +190,7 @@ def write_lensdb_xml(self, qApp):
         print(userpath)
         self.lensdbtree.write(os.path.join(userpath, '.pyexiftoolgui', 'lensdb.xml'))
     except:
-            QMessageBox.critical(self, "Error!", "Unable to open lensdb for writing" )
+        QMessageBox.critical(self, "Error!", "Unable to open lensdb for writing" )
 
 
 def deletelens(self, qApp):

--- a/scripts/petgfunctions.py
+++ b/scripts/petgfunctions.py
@@ -104,6 +104,13 @@ def exiftool_version_level_text(self):
         self.statusbar.showMessage("Your exiftoolversion is " + str(self.exiftoolversion))
     #print "exiftoolversion : " + self.exiftoolversion
 
+def find_on_path(tool):
+    """ Find the first occurrence of a tool on the path."""
+    paths = os.environ["PATH"].split(";")
+    for path in paths:
+        path = os.path.join(path, tool)
+        if os.path.exists(path):
+            return path
 
 def tool_check( self ):
     # We need this startup check as long as we don't have a package
@@ -113,10 +120,13 @@ def tool_check( self ):
         self.exiftoolprog = self.exiftooloption.text()
     else:
         self.exiftoolprog = "exiftool"
+        if (self.OSplatform in ("Windows", "win32")):
+            self.exiftoolprog = find_on_path("exiftool.exe")
+
     # Check for exiftool, based on the setting or no setting above
     if (self.OSplatform in ("Windows", "win32")):
-        if ("exiftool.exe" in self.exiftoolprog) or ("Exiftool.exe" in self.exiftoolprog):
-            self.exiftool_dir = os.path.join(self.realfile_dir, "exiftool", "exiftool.exe")
+        if ("exiftool.exe" in self.exiftoolprog) or ("Exiftool.exe" in self.exiftoolprog) or not self.exiftoolprog:
+            #self.exiftool_dir = os.path.join(self.realfile_dir, "exiftool", "exiftool.exe")
             #self.exiftoolprog = self.exiftool_dir + "\exiftool.exe"
             if not os.path.isfile(self.exiftoolprog):
                 configure_message = "exiftool is missing or incorrectly configured in Preferences!\n"

--- a/scripts/pyexiftoolgui.py
+++ b/scripts/pyexiftoolgui.py
@@ -14,7 +14,7 @@
 # the GNU General Public Licence for more details.
 
 # This file is part of pyexiftoolgui.
-# pyexiftoolgui is a pySide script program that reads and writes  
+# pyexiftoolgui is a pySide script program that reads and writes
 # gps tags from/to files. It can use a "reference" image to write the
 # gps tags to a multiple set of files that are taken at the same
 # location.
@@ -33,7 +33,7 @@ from PySide.QtGui import *
 # Very first check on version
 if sys.version_info<(2,7,0):
     sys.stderr.write("\n\nYou need python 2.7 or later to use pyexiftoolgui\n")
-    exit(1) 
+    exit(1)
 else:
     print("\nProgram start: We are on python " + sys.version)
 
@@ -185,7 +185,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 #        petgfunctions.remove_workspace( self )
 #        try:
 #        fldr = os.mkdir(self.tmpworkdir)
-#        except: 
+#        except:
 #        if self.logtofile:
 #            logging.info(self.tmpworkdir + " already exists.")
 
@@ -215,7 +215,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         petgfilehandling.read_defined_lenses(self, qApp)
 
         # Initialize Combobox mass change tab
-        '''self.grouplist = [ 
+        '''self.grouplist = [
         self.tr('exif'),
         self.tr('jfif'),
         self.tr('gps'),
@@ -252,7 +252,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         petgfunctions.loadimages(self, selectedimages, qApp)
         # If we alread did some copying or simply working on the GPS:edit tab we need to clean it after loading new images
         #petgfunctions.clear_gps_fields(self)
- 
+
 
     def load_cmd_images(self, args):
         ''' load images from command line args'''
@@ -323,7 +323,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 # Menu actions/functions
     def show_about_window(self):
         self.aboutbox = QMessageBox()
-        
+
         self.licenselabel = QLabel()
         self.licensebutton = self.aboutbox.addButton(self.tr("License"), QMessageBox.ActionRole)
         self.donatelabel = QLabel()
@@ -340,7 +340,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.aboutbox.setText(programinfo.ABOUTMESSAGE)
 
         ret = self.aboutbox.exec_()
-        
+
     def show_license(self):
         petgfunctions.info_window(self)
 
@@ -355,7 +355,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 petgfunctions.create_args(self, qApp)
         except:
             self.the_no_photos_messagebox()
-         
+
     def export_metadata(self):
         try:
             if len(self.fileNames) == 0:
@@ -507,7 +507,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
     def convertdms2d(self):
         petgfunctions.convertLatLong(self,"dms2d")
-                
+
     def clear_gps_fields(self):
         petgfunctions.clear_gps_fields(self)
 
@@ -621,6 +621,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         qApp.processEvents()
         select_exiftool.setFileMode(QFileDialog.ExistingFile)
         select_exiftool.setViewMode(QFileDialog.Detail)
+        select_exiftool.setFilters(["exiftool.exe", "*.exe"])
         if select_exiftool.exec_():
             files_list = select_exiftool.selectedFiles()
             print("files_list[0]" + str(files_list[0]))
@@ -687,5 +688,5 @@ if __name__ == '__main__':
         print('Number of arguments: %d' % len(sys.argv))
         print('Argument List:' + str(sys.argv))
         frame.load_cmd_images(sys.argv[1:])
-        
+
     app.exec_()

--- a/scripts/pyexiftoolgui.py
+++ b/scripts/pyexiftoolgui.py
@@ -621,7 +621,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         qApp.processEvents()
         select_exiftool.setFileMode(QFileDialog.ExistingFile)
         select_exiftool.setViewMode(QFileDialog.Detail)
-        select_exiftool.setFilters(["exiftool.exe", "*.exe"])
+        if self.OSplatform in ("Windows", "win32"):
+            select_exiftool.setFilters(["exiftool.exe", "*.exe"])
         if select_exiftool.exec_():
             files_list = select_exiftool.selectedFiles()
             print("files_list[0]" + str(files_list[0]))


### PR DESCRIPTION
Addresses #25 

 - Added function to find the location of exiftool if it is on the path, 
 - Changed the prompt filter, (Windows only), to look for either exiftool.exe or *.exe.
 - Some changes to the logic for missing exiftool & missing config
 - Now looks to be working on Windows 10/Python 2.7.11